### PR TITLE
Fix bug with loot point modification

### DIFF
--- a/app/components/DialogsContainer.tsx
+++ b/app/components/DialogsContainer.tsx
@@ -37,7 +37,7 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Dialo
       dispatch(setDialog('NONE'));
     },
     onSetUserLootPoints: (user: UserEntry, loot_points: number) => {
-      dispatch(mutateUser({userid: user.id, loot_points: user.loot_points}));
+      dispatch(mutateUser({userid: user.id, loot_points}));
     },
     onSetQuestPublishState: (quest: QuestEntry, published: boolean) => {
       dispatch(mutateQuest({questid: quest.id, partition: quest.partition, published}));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const options = {
   },
   devServer: {
     host: '0.0.0.0',
+    disableHostCheck: true,
     contentBase: Path.join(__dirname, 'app'),
     publicPath: '/',
     port: port,


### PR DESCRIPTION
`mutateUser` should actually use the modified `loot_points` value, not just set it to the user's current loot.

Also added `disableHostCheck` to make testing in dev a bit more lenient WRT hostnames.